### PR TITLE
fix(pub_sub): made Notification.subscriptionURI an FQ absolute URI

### DIFF
--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -1,9 +1,9 @@
 name: Testing and Linting
 on:
   push:
-    branches: [main, csipaus.org/ns/v1.2, csipaus.org/ns/v1.3]
+    branches: [main, csipaus.org/ns/v1.2, csipaus.org/ns/v1.3, csipaus.org/ns/v1.3-beta/storage]
   pull_request:
-    branches: [main, csipaus.org/ns/v1.2, csipaus.org/ns/v1.3]
+    branches: [main, csipaus.org/ns/v1.2, csipaus.org/ns/v1.3, csipaus.org/ns/v1.3-beta/storage]
   workflow_dispatch:
 
 jobs:

--- a/src/envoy_schema/server/schema/sep2/pub_sub.py
+++ b/src/envoy_schema/server/schema/sep2/pub_sub.py
@@ -304,7 +304,7 @@ class Notification(SubscriptionBase):
         NotificationResourceCombined  # Instead we use this as our workaround for now
     ] = element(tag="Resource", default=None)
     status: NotificationStatus = element()
-    subscriptionURI: LocalAbsoluteUri = element()  # Subscription from which this notification was triggered.
+    subscriptionURI: HttpUri = element()  # Subscription from which this notification was triggered.
 
 
 class Condition(BaseXmlModelWithNS):

--- a/tests/data/notification.xml
+++ b/tests/data/notification.xml
@@ -10,5 +10,5 @@
         </Reading>
     </Resource>
     <status>0</status>
-    <subscriptionURI>/edev/8/sub/5</subscriptionURI>
+    <subscriptionURI>http://0.0.0.0/edev/8/sub/5</subscriptionURI>
 </Notification>

--- a/tests/data/notification_doe.xml
+++ b/tests/data/notification_doe.xml
@@ -23,5 +23,5 @@
         </DERControl>
     </Resource>
     <status>0</status>
-    <subscriptionURI>/edev/8/sub/5</subscriptionURI>
+    <subscriptionURI>https://example.com/edev/8/sub/5</subscriptionURI>
 </Notification>

--- a/tests/unit/server/test_pub_sub.py
+++ b/tests/unit/server/test_pub_sub.py
@@ -86,7 +86,7 @@ def test_notification_xml_reading():
     assert parsed_notif.resource.Readings[0].timePeriod.start == 12987364
     assert parsed_notif.resource.Readings[0].timePeriod.duration == 0
     assert parsed_notif.status == NotificationStatus.DEFAULT
-    assert parsed_notif.subscriptionURI == "/edev/8/sub/5"
+    assert parsed_notif.subscriptionURI == "http://0.0.0.0/edev/8/sub/5"
 
 
 def test_notification_xml_doe():


### PR DESCRIPTION
Came up testing Itron server. They return a https:// ....  result. XSD seems to suggest that this is the right call.